### PR TITLE
Community standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "BUG:"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behaviour:
+1. 
+2. 
+3. 
+4. ...
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest a feature to be added
+title: "FEATURE:"
+labels: Feature
+assignees: ''
+
+---
+
+**Describe the feature**
+A clear and concise description of what the feature should be.
+
+**Justification**
+Describe why this feature should be added
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+# Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+
+## Type of change
+
+Please mark the relevant options
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Screenshots
+
+Please provide screenshots or a screen recording of the visual changes associated with this PR.
+
+(Delete this section is not applicable)
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes with instructions so we can reproduce and any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+
+Describe test configurations here.
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+
+
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,7 +35,7 @@ Describe test configurations here.
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made the code speak for itself where possible and commented in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,92 @@
+
+# Contributor Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, **contact a member of our project team at lloyd.fletcher@ukaea.uk so that we can investigate the issue with confidentiality.**
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+****
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to Pyvale
+
+Thank you for wanting to contribute to the development of pyvale. Before contributing, please read this page, along with our [Code of Conduct](https://github.com/Computer-Aided-Validation-Laboratory/pyvale/blob/main/CODE_OF_CONDUCT.md) and [Security](https://github.com/Computer-Aided-Validation-Laboratory/pyvale/blob/main/SECURITY.md) guidelines.
+
+## Cloning the Repository
+
+You can clone the pyvale repository at https://github.com/Computer-Aided-Validation-Laboratory/pyvale. 
+
+Use the following command to install pyvale for development:
+```shell
+pip install pyvale
+```
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,40 @@ Code contributions should be associated with an issue or feature request. Please
 
 Please be aware that all Pyvale code is under the [MIT Licencse](https://github.com/Computer-Aided-Validation-Laboratory/pyvale?tab=MIT-1-ov-file). It is your responsiblity to ensure that all contributions are compatible with this.
 
+## AI Usage
+
+The Pyvale project has strict rules for AI usage:
+
+- **All AI usage in any form must be disclosed.** You must state the tool you used (e.g. Claude Code, Cursor, Amp) along with the extent that the work was AI-assisted.
+
+- **The human-in-the-loop must fully understand all code.** If you can't explain what your changes do and how they interact with the greater system without the aid of AI tools, do not contribute to this project.
+
+- **Issues and discussions can use AI assistance but must have a full human-in-the-loop.** This means that any content generated with AI must have been reviewed and edited_ by a human before submission. AI is very good at being overly verbose and including noise that distracts from the main point. Humans must do their research and trim this down.
+
+- **No AI-generated media is allowed (art, images, videos, audio, etc.).** Text and code are the only acceptable AI-generated content, per the other rules in this policy.
+
+- **Bad AI drivers will be denounced** People who produce bad contributions that are clearly AI (slop) will be added to our denouncement list. This list will be used to block all future contributions. 
+
+These rules apply only to outside contributions to Pyvale. Maintainers are exempt from these rules and may use AI tools at their discretion; they've proven themselves trustworthy to apply good judgment.
+
+### There are Humans Here
+
+Please remember that Pyvale is maintained by humans.
+
+Every discussion, issue, and pull request is read and reviewed by humans (and sometimes machines, too). It is a boundary point at which people interact with each other and the work done. It is rude and disrespectful to approach this boundary with low-effort, unqualified work, since it puts the burden of validation on the maintainer.
+
+In a perfect world, AI would produce high-quality, accurate work every time. But today, that reality depends on the driver of the AI. And today, most drivers of AI are just not good enough. So, until either the people get better, the AI gets better, or both, we have to have strict rules to protect maintainers.
+
+### AI is Welcome Here
+
+As a project, we welcome AI as a tool!
+
+**Our reason for the strict AI policy is not due to an anti-AI stance**, but instead due to the number of highly unqualified people using AI. It's the people, not the tools, that are the problem.
+
+I include this section to be transparent about the project's usage about AI for people who may disagree with it, and to address the misconception that this policy is anti-AI in nature.
+
+_This policy has been adapted from the [Ghostty AI policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md?plain=1). Credit goes to the [Ghostty](https://github.com/ghostty-org/ghostty/tree/main) team._
+
 ## Working on Pyvale
 
 ### Cloning the Repository
@@ -43,6 +77,10 @@ Once you have cloned the repository and have an issue to work on, create a branc
 git switch dev
 git switch -c branchname
 ```
+
+### Developer Guidance
+
+Much of Pyvale is written in Python. See our [Pyvale Developer Guide](https://github.com/Computer-Aided-Validation-Laboratory/pyvale/blob/main/designspec/README.md) for guidance on how to write Python code that best aligns with Pyvale's code values.
 
 ### Docstrings
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,105 @@
 
 Thank you for wanting to contribute to the development of pyvale. Before contributing, please read this page, along with our [Code of Conduct](https://github.com/Computer-Aided-Validation-Laboratory/pyvale/blob/main/CODE_OF_CONDUCT.md) and [Security](https://github.com/Computer-Aided-Validation-Laboratory/pyvale/blob/main/SECURITY.md) guidelines.
 
-## Cloning the Repository
+
+## Reporting Security Concerns
+
+If you see something that you believe may be a security concern in Pyvale, please follow the guidance on our [security page](https://github.com/Computer-Aided-Validation-Laboratory/pyvale/blob/main/SECURITY.md). Do **not** open a public GitHub issue for security concerns. 
+
+## Reporting Bugs
+
+If you find a bug that is not a security concern, report it on our [issues page](https://github.com/Computer-Aided-Validation-Laboratory/pyvale/issues). Use the "bug" tag to use the associated bug template to ensure the bug is captured in detail.
+
+## Making Feature Requests
+
+We encourage you to share your ideas for adding features to Pyvale. If there is a feature you want added, you can head over to our [issues page](https://github.com/Computer-Aided-Validation-Laboratory/pyvale/issues) and use the "feature" tag to submit a request. We will then be able to discuss and provide feedback on your request.
+
+## Contributing New Code
+
+Code contributions should be associated with an issue or feature request. Please ensure you have submitted one of these before you contribute code.
+
+## Licensing
+
+Please be aware that all Pyvale code is under the [MIT Licencse](https://github.com/Computer-Aided-Validation-Laboratory/pyvale?tab=MIT-1-ov-file). It is your responsiblity to ensure that all contributions are compatible with this.
+
+## Working on Pyvale
+
+### Cloning the Repository
 
 You can clone the pyvale repository at https://github.com/Computer-Aided-Validation-Laboratory/pyvale. 
 
-Use the following command to install pyvale for development:
+Use the following command in the pyvale directory to install pyvale for development:
 ```shell
-pip install pyvale
+pip install pyvale -e .
 ```
 
+We recommend installing Pyvale into a virtual environment of your choice as pyvale requires python 3.11.  If you need help setting up your virtual environment and installing pyvale head over to our [installation guide](https://computer-aided-validation-laboratory.github.io/pyvale/install/install.html).
+
+### Make a Branch
+
+Once you have cloned the repository and have an issue to work on, create a branch from dev to work on.
+```shell
+git switch dev
+git switch -c branchname
+```
+
+### Docstrings
+
+Docstrings are used to support making Pyvale documentation, as well as being a useful tool to help developers understand code that has been contributed. All contributions should include docstrings. These should include a short summary of what a function or class does, the parameters it takes, and what it returns.
+
+See below for an example of how we structure our docstrings.
+```python
+def check_strain_files(strain_files: str | Path) -> list[str]:
+    """
+    Check for strain/deformation files in the given path and return their filenames.
+
+    Parameters
+    ----------
+    strain_files : str or pathlib.Path
+        Path or glob pattern pointing to the strain/deformation files.
+
+    Returns
+    -------
+    list[str]
+        A sorted list of filenames (not full paths) matching the input path/pattern.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no files matching the given path or pattern are found.
+
+    Examples
+    --------
+    >>> check_strain_files("data/strain_*.tif")
+    ['strain_001.tif', 'strain_002.tif', 'strain_003.tif']
+    """
+
+    filenames = []
+
+    # Find deformation image files
+    files = sorted(glob.glob(str(strain_files)))
+    if not files:
+        raise FileNotFoundError(f"No DIC data found: {strain_files}")
+
+    for file in files:
+        filenames.append(os.path.basename(file))
+
+    return filenames
+```
+
+### Testing
+
+Pyvale uses [pytest](https://github.com/pytest-dev/pytest/). Please test your code before submitting a pull request. You can create your tests in the (pyvale/tests) directory. 
+
+To run all tests, use the following command in the (pyvale) directory:
+```shell
+pytest tests
+```
+For more information on using pytest, refer to the [pytest docs](https://docs.pytest.org/en/stable/).
+
+
+## Creating a Pull Request
+
+Once you are satisfied with your contribution and have carried out tests, create a [pull request](https://github.com/Computer-Aided-Validation-Laboratory/pyvale/pulls) to merge into dev. 
+
+The included pull request template will allow you to provide all the details needed for us to review your code. Once it has been reviewed it can be merged into dev where it will eventually be merged into main.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security
+
+## Reporting a Security Concern
+
+If you believe you have found a security vulnerability in pyvale:
+
+- Do **not** open a public GitHub issue
+- Contact a member of the development team at lloyd.fletcher@ukaea.uk with a description of the issue. Include steps to reproduce.
+- Include as much detail as possible for us to assess the issue such as the platform you are using and code version.
+
+We will acknowledge your report as soon as possible and update you on our assessment and fixes.
+
+Thank you for keeping pyvale and its use base safe.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ If you believe you have found a security vulnerability in pyvale:
 
 We will acknowledge your report as soon as possible and update you on our assessment and fixes.
 
-Thank you for keeping pyvale and its use base safe.
+Thank you for keeping pyvale and its user base safe.


### PR DESCRIPTION
This will add the following to adhere to the recommended [community standards](https://github.com/github/opensource.guide/community):

Markdown files for:
- Code of Conduct
- Contributing
- Security

Markdown templates for:
- Issues (bugs)
- Issues (feature requests)
- Pull requests

---

Notes:
- The issue and pull request templates should not work until they are in main
- The links to markdown files such as in the CONTRIBUTING.md file are pointing towards the main branch in preparation for a main merge. They do not currently work as these pages technically don't exist yet.

Please read and check for any typos etc. Additionally, I would like comments on what else could be added here. Specifically I am interested in:
- Are the contact avenues included are acceptable? Do we need to consider improvements in the future?
- Generative AI policies for future contributors in CONTRIBUTING.md
- More development practice guidance - I have included docstrings and local testing, but you may wish to add more to this. Things like branch naming conventions and an updating documentation guide for example.
- The templates are generic and some of it might not seem relevant for us. Feel free to recommend more appropriate sections if what I have doesn't fit well.

