### PR TITLE
Fix builds on macos with Xcode clang compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,26 @@ function(apply_compile_flags target_name)
             message(STATUS "Applying MSVC release flags for ${target_name}")
             target_compile_options(${target_name} PRIVATE /O2)
         endif()
+    elseif(APPLE)
+        # MacOS
+
+        # Apple has explicitly disabled OpenMP support in their compilers, a
+        # workaround is to pass the -Xclang flag to the compile and link options
+        # while having the OpenMP runtime (built using Xcode compilers) installed
+        # on the machine
+        # see: https://mac.r-project.org/openmp/
+        target_compile_options(${target_name} PRIVATE -std=c++17 -Xclang -fopenmp)
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            message(STATUS "Applying debug flags for ${target_name}")
+            target_compile_options(${target_name} PRIVATE -O0 -g)
+            target_link_options(${target_name} PRIVATE -Xclang -fopenmp -g)
+        else()
+            message(STATUS "Applying release flags for ${target_name}")
+            target_compile_options(${target_name} PRIVATE -O3)
+            target_link_options(${target_name} PRIVATE -Xclang -fopenmp)
+        endif()
     else()
-        # Linux / macOS
+        # Linux
         target_compile_options(${target_name} PRIVATE -std=c++17 -fopenmp)
         if(CMAKE_BUILD_TYPE STREQUAL "Debug")
             message(STATUS "Applying debug flags for ${target_name}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,7 @@ function(apply_compile_flags target_name)
             message(STATUS "Applying MSVC release flags for ${target_name}")
             target_compile_options(${target_name} PRIVATE /O2)
         endif()
-    elseif(APPLE)
-        # MacOS
-
+    elseif(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         # Apple has explicitly disabled OpenMP support in their compilers, a
         # workaround is to pass the -Xclang flag to the compile and link options
         # while having the OpenMP runtime (built using Xcode compilers) installed
@@ -88,7 +86,7 @@ function(apply_compile_flags target_name)
             target_link_options(${target_name} PRIVATE -Xclang -fopenmp)
         endif()
     else()
-        # Linux
+        # Linux / macOS (not Xcode clang)
         target_compile_options(${target_name} PRIVATE -std=c++17 -fopenmp)
         if(CMAKE_BUILD_TYPE STREQUAL "Debug")
             message(STATUS "Applying debug flags for ${target_name}")


### PR DESCRIPTION
Builds on my macbook currently fail due to openmp not being supported by Xcode compilers, updating CMakeLists to pass the `-Xclang` flag needed to get builds to work. See [here](https://mac.r-project.org/openmp/) for details on this workaround
