### PR TITLE
updated  radial return to use flat arrays for efficiency. 

### DIFF
--- a/src/pyvale/vfm/radialreturn.py
+++ b/src/pyvale/vfm/radialreturn.py
@@ -228,10 +228,11 @@ def radial_return(
         # sig_xy = sig_xy_prev + G * delta_gamma_xy  (note: shear strain is engineering shear strain, so no factor of 2 needed here)
         trial_stress_xy = stress_state[t_prev, 2, :, :] + shear_modulus * incremental_strain[t, 2, :, :]
        
-        # assemble trial stress into a single array  (shape: component, y, x)
-        trial_stress = np.stack((trial_stress_xx, trial_stress_yy, trial_stress_xy), axis=0)
-        # reshape trial stress to shape (datapoints, component) 
-        trial_stress_flat = np.moveaxis(trial_stress, 0, -1).reshape(num_datapoints, 3)
+        # Keep the component fields flattened through the return mapping. This
+        # avoids stacking and transposing the full stress field each timestep.
+        trial_stress_xx_flat = trial_stress_xx.ravel()
+        trial_stress_yy_flat = trial_stress_yy.ravel()
+        trial_stress_xy_flat = trial_stress_xy.ravel()
 
 
         # == CHECK YIELD CRITERION ==
@@ -241,10 +242,10 @@ def radial_return(
         # for the trial stress state at each point. This is used to evaluate the yield criterion 
         # and determine which points have yielded.
         yield_stress_measure[:] = 1/3 * (
-            trial_stress_xx.ravel() ** 2
-            + trial_stress_yy.ravel() ** 2
-            - trial_stress_xx.ravel() * trial_stress_yy.ravel()
-            + (3 * trial_stress_xy.ravel() ** 2)
+            trial_stress_xx_flat ** 2
+            + trial_stress_yy_flat ** 2
+            - trial_stress_xx_flat * trial_stress_yy_flat
+            + (3 * trial_stress_xy_flat ** 2)
         )
 
         # Compute yield stress for current plastic strain using the active
@@ -276,9 +277,15 @@ def radial_return(
         # ksi = (1/6)*(sig_xx + sig_yy)^2 + (1/2)*(sig_yy - sig_xx)^2 + 2*(sig_xy)^2
         # This is the projected invariant used by this plane-stress return-mapping implementation.
         ksi[plasticity_mask] = (
-            1 / 6 * np.sum(trial_stress_flat[plasticity_mask, 0:2], axis=1) ** 2
-            + 0.5 * (trial_stress_flat[plasticity_mask, 1] - trial_stress_flat[plasticity_mask, 0]) ** 2
-            + 2 * trial_stress_flat[plasticity_mask, 2] ** 2
+            1 / 6 * (
+                trial_stress_xx_flat[plasticity_mask]
+                + trial_stress_yy_flat[plasticity_mask]
+            ) ** 2
+            + 0.5 * (
+                trial_stress_yy_flat[plasticity_mask]
+                - trial_stress_xx_flat[plasticity_mask]
+            ) ** 2
+            + 2 * trial_stress_xy_flat[plasticity_mask] ** 2
         )
 
         # Compute plastic criterion 
@@ -302,10 +309,8 @@ def radial_return(
         # Newton-Raphson iteration to solve for plastic_multiplier such that plastic_criterion -> 0
         # stress sum and difference terms are trial-state invariants used in derivatives below
         # and remain fixed during Newton updates. Hence, compute once before iteration.
-        trial_stress_sum_sq = np.sum(trial_stress_flat[:, 0:2], axis=1) ** 2
-        trial_stress_diff_sq = (trial_stress_flat[:, 1] - trial_stress_flat[:, 0]) ** 2
-        # Set current stress state to the trial elastic stress; this will be updated for plastic points after the return-mapping iteration
-        stress_flat = trial_stress_flat.copy()
+        trial_stress_sum_sq = (trial_stress_xx_flat + trial_stress_yy_flat) ** 2
+        trial_stress_diff_sq = (trial_stress_yy_flat - trial_stress_xx_flat) ** 2
         i = 0
         while np.any(error > error_tolerance) and (i < iteration_limit):
             # Compute derivative of plastic criterion with respect to plastic_multiplier
@@ -321,7 +326,7 @@ def radial_return(
                 )
                 - 2
                 * shear_modulus_flat
-                * (trial_stress_diff_sq + 4 * stress_flat[:, 2] ** 2)
+                * (trial_stress_diff_sq + 4 * trial_stress_xy_flat ** 2)
                 / (1 + 2 * shear_modulus_flat * plastic_multiplier) ** 3
             )
 
@@ -407,7 +412,7 @@ def radial_return(
                         / (3 * (1 - poissons_ratio_flat))
                     ) ** 2
                 )
-                + (0.5 * trial_stress_diff_sq + 2 * stress_flat[:, 2] ** 2)
+                + (0.5 * trial_stress_diff_sq + 2 * trial_stress_xy_flat ** 2)
                 / (1 + 2 * shear_modulus_flat * plastic_multiplier) ** 2
             )
             ksi_all = np.maximum(ksi_all, 0)
@@ -470,24 +475,23 @@ def radial_return(
         correction_factor_avg = 0.5 * (correction_factor_1 + correction_factor_2)
         correction_factor_diff = 0.5 * (correction_factor_1 - correction_factor_2)
 
-        # Apply correction factors to trial stress to obtain corrected stress on yield surface.
-        stress_flat_corrected = np.column_stack(
-            (
-            correction_factor_avg * stress_flat[:, 0] + correction_factor_diff * stress_flat[:, 1],
-            correction_factor_diff * stress_flat[:, 0] + correction_factor_avg * stress_flat[:, 1],
-            correction_factor_2 * stress_flat[:, 2],
-            )
+        # Keep elastic trial points and overwrite only yielded points with the
+        # corrected values. The component-major view is layout-compatible with
+        # the stored (component, y, x) state.
+        state_flat = stress_state[t].reshape(3, num_datapoints)
+        state_flat[0] = trial_stress_xx_flat
+        state_flat[1] = trial_stress_yy_flat
+        state_flat[2] = trial_stress_xy_flat
+        state_flat[0, plasticity_mask] = (
+            correction_factor_avg[plasticity_mask] * trial_stress_xx_flat[plasticity_mask]
+            + correction_factor_diff[plasticity_mask] * trial_stress_yy_flat[plasticity_mask]
         )
-
-        # Keep elastic trial points and overwrite only yielded points with corrected stresses.
-        stress_flat[plasticity_mask] = stress_flat_corrected[plasticity_mask]
-
-        # Internal state: the return-mapped stress for all points, never patched by unloading.
-        # This is what the next step's trial-stress predictor must use.
-        stress_state[t, :, :, :] = np.moveaxis(
-            stress_flat.reshape(size_y, size_x, 3),
-            -1,
-            0,
+        state_flat[1, plasticity_mask] = (
+            correction_factor_diff[plasticity_mask] * trial_stress_xx_flat[plasticity_mask]
+            + correction_factor_avg[plasticity_mask] * trial_stress_yy_flat[plasticity_mask]
+        )
+        state_flat[2, plasticity_mask] = (
+            correction_factor_2[plasticity_mask] * trial_stress_xy_flat[plasticity_mask]
         )
 
 
@@ -513,20 +517,21 @@ def radial_return(
                 if t > 0: 
                     unload_mask = prev_plasticity_mask & (~plasticity_mask)  # Points that were plastic in the previous step but are now elastic
                     if np.any(unload_mask):
-                        out_flat = np.moveaxis(stress_output[t], 0, -1).reshape(num_datapoints, 3)
-                        prev_out_flat = np.moveaxis(stress_output[t - 1], 0, -1).reshape(num_datapoints, 3)
-                        out_flat[unload_mask] = prev_out_flat[unload_mask]
-                        stress_output[t] = np.moveaxis(out_flat.reshape(size_y, size_x, 3), -1, 0)
+                        out_flat = stress_output[t].reshape(3, num_datapoints)
+                        prev_out_flat = stress_output[t - 1].reshape(3, num_datapoints)
+                        out_flat[:, unload_mask] = prev_out_flat[:, unload_mask]
 
             case EUnloading.LinearExtrapolation:
                 if t > 1: 
                     unload_mask = prev_plasticity_mask & (~plasticity_mask)  # Points that were plastic in the previous step but are now elastic
                     if np.any(unload_mask):
-                        out_flat = np.moveaxis(stress_output[t], 0, -1).reshape(num_datapoints, 3)
-                        prev_out_flat = np.moveaxis(stress_output[t - 1], 0, -1).reshape(num_datapoints, 3)
-                        prev2_out_flat = np.moveaxis(stress_output[t - 2], 0, -1).reshape(num_datapoints, 3)
-                        out_flat[unload_mask] = (prev_out_flat[unload_mask] + (prev_out_flat[unload_mask] - prev2_out_flat[unload_mask]) )
-                        stress_output[t] = np.moveaxis(out_flat.reshape(size_y, size_x, 3), -1, 0)
+                        out_flat = stress_output[t].reshape(3, num_datapoints)
+                        prev_out_flat = stress_output[t - 1].reshape(3, num_datapoints)
+                        prev2_out_flat = stress_output[t - 2].reshape(3, num_datapoints)
+                        out_flat[:, unload_mask] = (
+                            2.0 * prev_out_flat[:, unload_mask]
+                            - prev2_out_flat[:, unload_mask]
+                        )
             case _:
                 # Defensive fallback; validated once before the timestep loop.
                 raise ValueError(

--- a/tests/vfm/test_radial_return.py
+++ b/tests/vfm/test_radial_return.py
@@ -1,3 +1,150 @@
+"""Regression tests for the vectorised plane-stress radial-return mapping."""
+
+import numpy as np
+
+from pyvale.vfm.hardening import HardeningLinear
+from pyvale.vfm.radialreturn import EUnloading, radial_return
+
+
+def _maps(
+    shape: tuple[int, int] = (1, 1),
+    *,
+    elastic_modulus: float = 210_000.0,
+    poissons_ratio: float = 0.3,
+    yield_strength: float = 250.0,
+    hardening_modulus: float = 1_000.0,
+) -> dict[str, np.ndarray]:
+    return {
+        "elastic_modulus": np.full(shape, elastic_modulus),
+        "poissons_ratio": np.full(shape, poissons_ratio),
+        "yield_strength": np.full(shape, yield_strength),
+        "hardening_modulus": np.full(shape, hardening_modulus),
+    }
+
+
+def _radial_return(
+    strain: np.ndarray,
+    maps: dict[str, np.ndarray],
+    *,
+    unloading: EUnloading = EUnloading.NoCompensation,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    return radial_return(
+        strain,
+        maps,
+        maps["elastic_modulus"],
+        maps["poissons_ratio"],
+        HardeningLinear(),
+        unloading=unloading,
+    )
+
+
+def test_radial_return_zero_strain_returns_zero_outputs() -> None:
+    strain = np.zeros((5, 3, 2, 4), dtype=np.float64)
+    stress, equivalent_stress, yield_map, peeq = _radial_return(strain, _maps((2, 4)))
+
+    np.testing.assert_array_equal(stress, np.zeros_like(stress))
+    np.testing.assert_array_equal(equivalent_stress, np.zeros_like(equivalent_stress))
+    np.testing.assert_array_equal(yield_map, np.zeros((5, 2, 4), dtype=bool))
+    np.testing.assert_array_equal(peeq, np.zeros_like(peeq))
+
+
+def test_radial_return_component_major_vectorisation_matches_plane_stress_hooke_law() -> None:
+    """Protect the flattened component-major path against component reordering."""
+
+    elastic_modulus = 190_000.0
+    poissons_ratio = 0.28
+    maps = _maps(
+        (2, 3),
+        elastic_modulus=elastic_modulus,
+        poissons_ratio=poissons_ratio,
+        yield_strength=1.0e9,
+        hardening_modulus=0.0,
+    )
+    strain = np.zeros((3, 3, 2, 3), dtype=np.float64)
+    strain[0, 0] = [[1.0e-4, 2.0e-4, -1.0e-4], [5.0e-5, -3.0e-5, 8.0e-5]]
+    strain[0, 1] = [[2.0e-5, -1.5e-4, 3.0e-5], [9.0e-5, 1.1e-4, -2.0e-5]]
+    strain[0, 2] = [[4.0e-5, -2.0e-5, 1.0e-5], [3.0e-5, -1.0e-5, 2.0e-5]]
+    strain[1] = 1.4 * strain[0]
+    strain[2] = 0.6 * strain[0]
+
+    stress, equivalent_stress, yield_map, peeq = _radial_return(strain, maps)
+    factor = elastic_modulus / (1.0 - poissons_ratio**2)
+    expected = np.empty_like(stress)
+    expected[:, 0] = factor * (strain[:, 0] + poissons_ratio * strain[:, 1])
+    expected[:, 1] = factor * (poissons_ratio * strain[:, 0] + strain[:, 1])
+    expected[:, 2] = elastic_modulus / (1.0 + poissons_ratio) * strain[:, 2]
+
+    np.testing.assert_allclose(stress, expected, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(
+        equivalent_stress,
+        np.sqrt(expected[:, 0] ** 2 + expected[:, 1] ** 2 - expected[:, 0] * expected[:, 1] + 3.0 * expected[:, 2] ** 2),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    assert not np.any(yield_map)
+    assert not np.any(peeq)
+
+
+def test_radial_return_linear_hardening_material_point_regression() -> None:
+    """Freeze a plastic history so performance refactors preserve its solution."""
+
+    maps = _maps()
+    strain = np.zeros((31, 3, 1, 1), dtype=np.float64)
+    strain[:, 0, 0, 0] = np.linspace(0.0, 0.01, strain.shape[0])
+
+    stress, equivalent_stress, yield_map, peeq = _radial_return(strain, maps)
+
+    np.testing.assert_allclose(
+        stress[-1, :, 0, 0],
+        [300.21399336, 149.77706528, 0.0],
+        rtol=1e-9,
+        atol=1e-9,
+    )
+    np.testing.assert_allclose(equivalent_stress[-1, 0, 0], 259.9931541603503, rtol=1e-10)
+    np.testing.assert_allclose(peeq[-1, 0, 0], 0.009993153330089927, rtol=1e-10)
+    assert int(np.count_nonzero(yield_map)) == 27
+
+
+def test_radial_return_unloading_modes_patch_output_not_plastic_state() -> None:
+    maps = _maps()
+    strain = np.zeros((4, 3, 1, 1), dtype=np.float64)
+    strain[:, 0, 0, 0] = [0.0, 0.006, 0.004, 0.002]
+
+    no_compensation = _radial_return(strain, maps, unloading=EUnloading.NoCompensation)
+    constant = _radial_return(strain, maps, unloading=EUnloading.ConstantStrain)
+    linear = _radial_return(strain, maps, unloading=EUnloading.LinearExtrapolation)
+
+    np.testing.assert_array_equal(no_compensation[2].ravel(), [False, True, False, True])
+    np.testing.assert_allclose(constant[0][2], constant[0][1], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(linear[0][2], 2.0 * linear[0][1] - linear[0][0], rtol=1e-12, atol=1e-12)
+    assert not np.allclose(no_compensation[0][2], constant[0][2])
+    np.testing.assert_allclose(no_compensation[3], constant[3], rtol=0.0, atol=0.0)
+
+
+def test_radial_return_handles_mixed_elastic_and_plastic_heterogeneous_points() -> None:
+    maps = _maps((2, 2))
+    maps["yield_strength"][0, 0] = 100.0
+    maps["yield_strength"][1, 1] = 1_500.0
+    strain = np.zeros((12, 3, 2, 2), dtype=np.float64)
+    strain[:, 0] = np.linspace(0.0, 0.005, strain.shape[0])[:, None, None]
+
+    stress, equivalent_stress, yield_map, peeq = _radial_return(strain, maps)
+
+    assert stress.shape == strain.shape
+    assert equivalent_stress.shape == (12, 2, 2)
+    assert yield_map[-1, 0, 0]
+    assert not yield_map[-1, 1, 1]
+    assert peeq[-1, 0, 0] > 0.0
+    assert peeq[-1, 1, 1] == 0.0
+
+# ---------------------------------------------------------------------------
+# Legacy commented tests retained for future reference.
+#
+# These tests predate the current parameter-map radial_return API. The
+# downsampled real-data fixture is particularly useful as a template for a
+# future regression test once adapted to the current interface.
+# ---------------------------------------------------------------------------
+#
 # from __future__ import annotations
 
 # from pathlib import Path


### PR DESCRIPTION
Use flat arrays in radial return. Makes computation about 10% less expensive as no packing / unpacking