### PR TITLE
Precomputation of invariant quantities for radial return and batch evaluation of egi metric

### DIFF
--- a/src/pyvale/vfm/constlaws.py
+++ b/src/pyvale/vfm/constlaws.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from copy import copy
+from typing import Self
 
 import numpy as np
 import numpy.typing as npt
@@ -8,7 +10,11 @@ from pyvale.vfm.constlaw import (
     IConstitutiveLaw,
 )
 from pyvale.vfm.hardening import IHardeningFunction
-from pyvale.vfm.radialreturn import radial_return
+from pyvale.vfm.radialreturn import (
+    RadialReturnPreparedInputs,
+    prepare_radial_return_inputs,
+    radial_return,
+)
 
 
 @dataclass(slots=True)
@@ -21,17 +27,34 @@ class IsotropicVonMisesElastoplasticity(IConstitutiveLaw):
     ``elastic_modulus`` and ``poissons_ratio`` plus whichever parameters the
     hardening law needs. The label arguments allow the elastic parameters to
     be renamed if your parameter dictionary uses different keys
+
+    Attributes
+    ----------
+    hardening_function : IHardeningFunction
+        The hardening function to use for the plasticity model.
+    elastic_modulus_label : str
+        The label for the elastic modulus parameter in the constitutive parameter maps.
+    poissons_ratio_label : str
+        The label for the Poisson's ratio parameter in the constitutive parameter maps.
+    error_tolerance : float
+        The error tolerance for the newton-raphson optimisation of the radial return algorithm.
     """
 
     hardening_function: IHardeningFunction
     elastic_modulus_label: str
     poissons_ratio_label: str
+    error_tolerance: float
+    cache_radial_return: bool
+    _prepared_inputs: RadialReturnPreparedInputs | None
 
     def __init__(
         self,
         hardening_function: IHardeningFunction,
         elastic_modulus_label: str | None = None,
-        poissons_ratio_label: str | None = None
+        poissons_ratio_label: str | None = None,
+        *,
+        error_tolerance: float = 1.0e-8,
+        cache_radial_return: bool = True,
     ) -> None:
         self.hardening_function = hardening_function
 
@@ -44,6 +67,74 @@ class IsotropicVonMisesElastoplasticity(IConstitutiveLaw):
             self.poissons_ratio_label = poissons_ratio_label
         else:
             self.poissons_ratio_label = "poissons_ratio"
+
+        if not np.isfinite(error_tolerance) or error_tolerance <= 0.0:
+            raise ValueError("error_tolerance must be finite and greater than zero")
+        self.error_tolerance = float(error_tolerance)
+        self.cache_radial_return = bool(cache_radial_return)
+        self._prepared_inputs = None
+
+    def prepare_for_optimisation(
+        self,
+        strain: npt.NDArray[np.float64],
+        *,
+        error_tolerance: float,
+        fixed_elastic_parameter_maps: dict[str, npt.NDArray[np.float64]] | None = None,
+        cache_radial_return: bool = True,
+    ) -> Self:
+        """Return a phase-local law with reusable radial-return inputs.
+
+        The returned shallow copy is used only for optimiser candidate
+        evaluations. Constitutive configuration, including the read-only
+        hardening evaluator, is shared; the optimisation tolerance and
+        prepared radial-return inputs belong to the returned law. Set
+        ``cache_radial_return`` to ``False`` to retain the optimisation
+        tolerance without preparing or using cached inputs.
+
+        The original law therefore retains its reconstruction tolerance for
+        final stress maps and ordinary direct calls. This allows the optimiser
+        to use a more relaxed tolerance for speed, while the final stress maps are
+        calculated with a more stringent tolerance for accuracy.
+
+        The prepared inputs are used to accelerate the radial return algorithm
+        by precomputing invariant quantities that depend on the strain field
+        and elastic parameters. If the elastic parameters are fixed, they can
+        be provided in `fixed_elastic_parameter_maps` to avoid redundant calculations.
+
+        A slice-wise phase calls this method first for the full field and then
+        once per local slice. A shallow copy avoids duplicating the existing
+        full-field cache; the local cache prepared below simply replaces it on
+        the new law.
+        """
+
+        prepared_law = copy(self)
+        if not np.isfinite(error_tolerance) or error_tolerance <= 0.0:
+            raise ValueError("error_tolerance must be finite and greater than zero")
+        prepared_law.error_tolerance = float(error_tolerance)
+        prepared_law.cache_radial_return = bool(cache_radial_return)
+        elastic_modulus = None
+        poissons_ratio = None
+
+        # If phase-local fixed elastic parameters have been provided,
+        # unpack elastic modulus and Poissons ratio.
+        if fixed_elastic_parameter_maps is not None:
+            elastic_modulus = fixed_elastic_parameter_maps.get(
+                self.elastic_modulus_label
+            )
+            poissons_ratio = fixed_elastic_parameter_maps.get(
+                self.poissons_ratio_label
+            )
+        if prepared_law.cache_radial_return:
+            # Prepare invariant inputs for the radial return algorithm, which
+            # depend on the strain field and, optionally, the elastic parameters.
+            prepared_law._prepared_inputs = prepare_radial_return_inputs(
+                strain,
+                elastic_modulus=elastic_modulus,
+                poissons_ratio=poissons_ratio,
+            )
+        else:
+            prepared_law._prepared_inputs = None
+        return prepared_law
 
     def get_identification_type(self) -> EIdentificationType:
         return EIdentificationType.Nonlinear
@@ -58,12 +149,24 @@ class IsotropicVonMisesElastoplasticity(IConstitutiveLaw):
         strain: npt.NDArray[np.float64],
         constitutive_parameter_maps: dict[str, npt.NDArray[np.float64]],
     ) -> npt.NDArray[np.float64]:
+        prepared_inputs = self._prepared_inputs if self.cache_radial_return else None
+        if (
+            prepared_inputs is not None
+            and prepared_inputs.strain_shape != tuple(strain.shape)
+        ):
+            # Slice-wise solvers may call this phase-local law with a smaller
+            # local field. Its full-field prepared inputs are not applicable;
+            # radial_return will create inputs for this direct call instead.
+            prepared_inputs = None
+
         stress, _, _, _ = radial_return(
             strain,
             constitutive_parameter_maps,
             constitutive_parameter_maps[self.elastic_modulus_label],
             constitutive_parameter_maps[self.poissons_ratio_label],
-            self.hardening_function
+            self.hardening_function,
+            error_tolerance=self.error_tolerance,
+            prepared_inputs=prepared_inputs,
         )
 
         return stress

--- a/src/pyvale/vfm/identification.py
+++ b/src/pyvale/vfm/identification.py
@@ -39,6 +39,7 @@ from pyvale.vfm.spatialparam import (
     PhaseSpatialState,
     evaluate_parameterisations_to_map,
 )
+from pyvale.vfm.spatialparamknown import SpatialParameterisationKnown
 
 
 def run_identification(
@@ -158,6 +159,18 @@ def run_identification(
                         phase_runtime.spatial_state.collect_degrees_of_freedom()
                     )
 
+                    # Prepare a phase-local constitutive law for optimisation,
+                    # which may include precomputed inputs for the radial return algorithm
+                    # to reduce repeated calculations.
+                    phase_constitutive_law = _prepare_phase_constitutive_law(
+                        identification_config.constitutive_law,
+                        phase_runtime,
+                        experiment_data,
+                        parameter_map_size,
+                        phase.optimisation_newton_tolerance,
+                        phase.cache_radial_return,
+                    )
+
                     # Emit a progress event to indicate the start of the current solve iteration within the phase.
                     _emit_solve_progress(
                         progress_callback,
@@ -171,7 +184,7 @@ def run_identification(
                     solve_started_at = time.perf_counter()
                     # Optimise the active DOFs to minimise the objective.
                     optimisation_result = phase.optimiser.optimise(
-                        identification_config.constitutive_law,
+                        phase_constitutive_law,
                         parameter_map_size,
                         phase_runtime.spatial_state.spatial_parameterisations,
                         phase_runtime.metrics,
@@ -375,6 +388,60 @@ def run_identification(
             input=input_metadata,
             config=config_snapshot,
         ),
+    )
+
+
+def _prepare_phase_constitutive_law(
+    constitutive_law: IConstitutiveLaw,
+    phase_runtime: "PhaseRuntime",
+    experiment_data: ExperimentData,
+    parameter_map_size: np.ndarray,
+    optimisation_newton_tolerance: float,
+    cache_radial_return: bool,
+) -> IConstitutiveLaw:
+    """Build an optional phase-local fast constitutive evaluator.
+
+    Constitutive laws without a preparation hook retain their existing
+    behaviour. Known elastic maps are supplied only when both are represented
+    by ``SpatialParameterisationKnown`` objects in this phase.
+    """
+
+    prepare = getattr(constitutive_law, "prepare_for_optimisation", None)
+    if prepare is None:
+        return constitutive_law
+
+    # If both elastic modulus and Poisson's ratio are represented by known
+    # spatial parameterisations, evaluate their maps and use them to compute
+    # invariant quantities for the radial return algorithm.
+    elastic_labels = (
+        getattr(constitutive_law, "elastic_modulus_label", None),
+        getattr(constitutive_law, "poissons_ratio_label", None),
+    )
+    fixed_elastic_parameter_maps = None
+    if all(isinstance(label, str) for label in elastic_labels):
+        labels = tuple(elastic_labels)
+        if all(
+            len(phase_runtime.spatial_parameterisations[label]) == 1
+            and isinstance(
+                phase_runtime.spatial_parameterisations[label][0],
+                SpatialParameterisationKnown,
+            )
+            for label in labels
+        ):
+            all_maps = phase_runtime.spatial_state.evaluate_parameter_maps(
+                parameter_map_size
+            )
+            fixed_elastic_parameter_maps = {
+                label: all_maps[label]
+                for label in labels
+            }
+
+    # Prepare a phase-local constitutive law with precomputed radial-return inputs.
+    return prepare(
+        experiment_data.strain,
+        error_tolerance=optimisation_newton_tolerance,
+        fixed_elastic_parameter_maps=fixed_elastic_parameter_maps,
+        cache_radial_return=cache_radial_return,
     )
 
 

--- a/src/pyvale/vfm/identificationconfig.py
+++ b/src/pyvale/vfm/identificationconfig.py
@@ -37,6 +37,20 @@ class IdentificationPhase:
     refinement_policy: IRefinementPolicy | None = None
     """Optional phase-level strategy for changing the spatial representation"""
 
+    optimisation_newton_tolerance: float = 1.0e-6
+    """Newton tolerance used only for optimiser candidate stress evaluations.
+
+    Final stress reconstruction uses the constitutive law's ordinary
+    tolerance (``1e-8`` for the radial-return implementation).
+    """
+
+    cache_radial_return: bool = True
+    """Cache radial-return inputs during optimisation for faster repeated calls.
+
+    Set to ``False`` to use the ordinary uncached constitutive evaluation for
+    every optimisation candidate, including independent slice-wise solves.
+    """
+
 
 @dataclass(slots=True)
 class IdentificationConfig:

--- a/src/pyvale/vfm/identificationresult.py
+++ b/src/pyvale/vfm/identificationresult.py
@@ -132,6 +132,8 @@ class PhaseConfigSnapshot:
     objective_function: ObjectSnapshot | None = None
     optimiser: ObjectSnapshot | None = None
     refinement_policy: ObjectSnapshot | None = None
+    optimisation_newton_tolerance: float = 1.0e-6
+    cache_radial_return: bool = True
 
     def to_dict(self) -> Summary:
         return _dataclass_to_dict(self)
@@ -633,6 +635,10 @@ def snapshot_phase_config(
             if refinement_policy is None
             else snapshot_object(refinement_policy)
         ),
+        optimisation_newton_tolerance=float(
+            getattr(phase, "optimisation_newton_tolerance", 1.0e-6)
+        ),
+        cache_radial_return=bool(getattr(phase, "cache_radial_return", True)),
     )
 
 

--- a/src/pyvale/vfm/metricequilibriumgap.py
+++ b/src/pyvale/vfm/metricequilibriumgap.py
@@ -6,6 +6,7 @@ import warnings
 
 import numpy as np
 import numpy.typing as npt
+from scipy.fft import irfftn, next_fast_len, rfftn
 from scipy.signal import correlate, correlate2d
 
 from pyvale.vfm.constlaw import IConstitutiveLaw
@@ -90,6 +91,11 @@ class EquilibriumGapMetric(IMetric):
     compute_spatiotemporal_rms : bool, optional
         Whether to compute the force-weighted spatial-temporal RMS scalar of
         the normalised gap. Default is True.
+    include_optimisation_diagnostics : bool, optional
+        Whether optimiser candidate evaluations retain full residual maps and
+        diagnostic fields. Default is True. Set to False for scalar objectives
+        that require only ``weighted_spatiotemporal_rms`` and ``window_size``.
+        Normal calls to ``evaluate`` always retain full diagnostics.
     pixel_area_scale : float, optional
         Scale factor for the pixel area when computing the volume. Default is 1.0.
         This is only required if mismatch in units between the pixel area and the stress field, 
@@ -99,6 +105,12 @@ class EquilibriumGapMetric(IMetric):
         Internal operator for evaluating the equilibrium gap, initialised in ``initialise()``.
         This operator contains the virtual strain fields, volume, window point counts, valid centre mask,
           longitudinal force, and force weights. Hence does not need to be recomputed for each evaluation, improving performance.
+    plot_virtual_field_schematic : bool, optional
+        Whether to plot a schematic of the virtual field and window. Default is False.
+    plot_virtual_window_raster : bool, optional
+        Whether to plot a raster of the valid virtual window centres. Default is False.
+    _kernel_fft_cache : dict[tuple[int, int], npt.NDArray[np.complex128]]
+        Internal cache of the FFT of the virtual strain fields for each unique FFT shape.
     """
 
     # Define attributes of EquilibriumGapMetric class with type annotations
@@ -110,10 +122,14 @@ class EquilibriumGapMetric(IMetric):
     valid_window_fill_fraction: float
     compute_temporal_rms: bool
     compute_spatiotemporal_rms: bool
+    include_optimisation_diagnostics: bool
     pixel_area_scale: float
     _operator: _EquilibriumGapOperator | None
     plot_virtual_field_schematic: bool
     plot_virtual_window_raster: bool
+    _kernel_fft_cache: dict[
+        tuple[int, int], npt.NDArray[np.complex128]
+    ]
 
     def __init__(
         self,
@@ -126,6 +142,7 @@ class EquilibriumGapMetric(IMetric):
         valid_window_fill_fraction: float = 0.5,
         compute_temporal_rms: bool = True,
         compute_spatiotemporal_rms: bool = True,
+        include_optimisation_diagnostics: bool = True,
         pixel_area_scale: float = 1.0,
         plot_virtual_field_schematic: bool = False,
         plot_virtual_window_raster: bool = False,
@@ -138,10 +155,14 @@ class EquilibriumGapMetric(IMetric):
         self.valid_window_fill_fraction = float(valid_window_fill_fraction)
         self.compute_temporal_rms = compute_temporal_rms
         self.compute_spatiotemporal_rms = compute_spatiotemporal_rms
+        self.include_optimisation_diagnostics = bool(
+            include_optimisation_diagnostics
+        )
         self.pixel_area_scale = pixel_area_scale
         self.plot_virtual_field_schematic = plot_virtual_field_schematic
         self.plot_virtual_window_raster = plot_virtual_window_raster
         self._operator = None
+        self._kernel_fft_cache = {}
         _validate_window_definition(
             self.window_size,
             self.sliding_pitch,
@@ -167,6 +188,9 @@ class EquilibriumGapMetric(IMetric):
             plot_virtual_field_schematic=self.plot_virtual_field_schematic,
             plot_virtual_window_raster=self.plot_virtual_window_raster,
         )
+        # Clear the kernel FFT cache, as the operator has changed
+        # and the cached FFTs are no longer valid.
+        self._kernel_fft_cache.clear()
 
     def evaluate(
         self,
@@ -181,6 +205,8 @@ class EquilibriumGapMetric(IMetric):
     def evaluate_equilibrium_gap(
         self,
         stress: npt.NDArray[np.float64],
+        *,
+        include_diagnostics: bool = True,
     ) -> EquilibriumGapResult:
         """Evaluate raw EGI and derived normalised RMS diagnostics."""
 
@@ -208,18 +234,24 @@ class EquilibriumGapMetric(IMetric):
         # Evaluate raw equilibrium gap for each window in the stress field, 
         # using the precomputed operator. raw_gap has shape (timesteps, y, x)
         raw_gap = _evaluate_raw_gap(stress, self._operator)
+        return self._result_from_raw_gap(
+            raw_gap,
+            include_diagnostics=include_diagnostics,
+        )
+
+    def _result_from_raw_gap(
+        self,
+        raw_gap: npt.NDArray[np.float64],
+        *,
+        include_diagnostics: bool,
+    ) -> EquilibriumGapResult:
+        """Apply masks, normalisation, aggregation, and result packaging."""
+
+        if self._operator is None:
+            raise RuntimeError("Equilibrium gap operator has not been prepared.")
+
         # Mask out invalid windows in the raw gap, setting them to NaN.
         raw_gap[:, ~self._operator.valid_centre_mask] = np.nan
-
-        # Debug plot
-        plot_raw_gap = False
-        if plot_raw_gap:
-            import matplotlib.pyplot as plt
-            tt = len(raw_gap)-1
-            plt.imshow(raw_gap[tt], cmap="viridis")
-            plt.colorbar()
-            plt.title("Raw Equilibrium Gap (timestep {tt})")
-            plt.show()
 
         normalised_gap = _normalise_raw_gap(
             raw_gap,
@@ -228,22 +260,23 @@ class EquilibriumGapMetric(IMetric):
         )
 
         weighted_temporal_rms = None
-        if self.compute_temporal_rms:
+        if include_diagnostics and self.compute_temporal_rms:
             weighted_temporal_rms = _calculate_weighted_temporal_rms(
                 normalised_gap,
                 self._operator.force_weights,
             )
 
         weighted_spatiotemporal_rms = None
-        if self.compute_spatiotemporal_rms:
+        # Compute weighted spatiotemporal RMS if requested, or if diagnostics
+        # are not included (to ensure the result is available for objective scaling).
+        if self.compute_spatiotemporal_rms or not include_diagnostics:
             weighted_spatiotemporal_rms = _calculate_nan_rms(
                 normalised_gap
                 * np.sqrt(self._operator.force_weights)[:, np.newaxis, np.newaxis]
             )
 
-        metric_result = MetricResult(
-            residual=normalised_gap,
-            additional_fields={
+        if include_diagnostics:
+            additional_fields = {
                 "raw_gap": raw_gap,
                 "normalised_gap": normalised_gap,
                 "weighted_temporal_rms": weighted_temporal_rms,
@@ -260,7 +293,18 @@ class EquilibriumGapMetric(IMetric):
                 "nominal_window_point_count": self._operator.nominal_window_point_count,
                 "valid_centre_mask": self._operator.valid_centre_mask,
                 "virtual_strain_fields": self._operator.virtual_strain_fields,
-            },
+            }
+            residual = normalised_gap
+        else:
+            additional_fields = {
+                "weighted_spatiotemporal_rms": weighted_spatiotemporal_rms,
+                "window_size": self.window_size.copy(),
+            }
+            residual = None
+
+        metric_result = MetricResult(
+            residual=residual,
+            additional_fields=additional_fields,
         )
         return EquilibriumGapResult(
             metric_result=metric_result,
@@ -269,6 +313,124 @@ class EquilibriumGapMetric(IMetric):
             weighted_temporal_rms=weighted_temporal_rms,
             weighted_spatiotemporal_rms=weighted_spatiotemporal_rms,
         )
+
+
+def evaluate_equilibrium_gap_batch(
+    stress: npt.NDArray[np.float64],
+    metrics: list[EquilibriumGapMetric],
+    *,
+    include_diagnostics: bool,
+) -> list[MetricResult]:
+    """Evaluate compatible EGI windows with shared stress FFTs.
+
+    The stress-volume fields are transformed once per stress component. Each
+    virtual field then requires only its cached kernel transform and one
+    inverse transform after summing the three component contributions.
+    """
+
+    if not metrics:
+        return []
+    if stress.ndim != 4 or stress.shape[1] != 3:
+        raise ValueError(
+            "Expected stress with shape (timesteps, 3, y, x), "
+            f"got {stress.shape}."
+        )
+
+    operators: list[_EquilibriumGapOperator] = []
+    for metric in metrics:
+        operator = metric._operator
+        if operator is None:
+            raise RuntimeError(
+                "Equilibrium gap operator has not been prepared. "
+                "Call initialise(...) before batch evaluation."
+            )
+        if stress.shape[0] != operator.longitudinal_force.shape[0]:
+            raise ValueError("Stress and EGI force histories have different lengths.")
+        if stress.shape[2:] != operator.valid_centre_mask.shape:
+            raise ValueError("Stress and EGI operator spatial shapes differ.")
+        operators.append(operator)
+
+    reference_volume = operators[0].volume
+    if any(
+        not np.array_equal(operator.volume, reference_volume)
+        for operator in operators[1:]
+    ):
+        raise ValueError(
+            "Batched EGI metrics must use identical integration volumes."
+        )
+
+    # Determine the maximum window size across all metrics to define the FFT shape.
+    max_rows = max(int(metric.window_size[0]) for metric in metrics)
+    max_cols = max(int(metric.window_size[1]) for metric in metrics)
+    # Determine the FFT shape for the stress and kernel transforms,
+    # using next_fast_len for efficiency. This ensures that the FFTs are
+    # computed over a shape that is at least as large as the stress field
+    # plus the maximum window size minus one, which is necessary for valid convolution.
+    fft_shape = (
+        next_fast_len(stress.shape[2] + max_rows - 1),
+        next_fast_len(stress.shape[3] + max_cols - 1),
+    )
+    # Compute the stress-volume fields by multiplying the stress components by the reference volume.
+    # Shape: (timesteps, 3, y, x)
+    stress_volume = np.nan_to_num(
+        stress * reference_volume[np.newaxis, np.newaxis],
+        nan=0.0,
+    )
+    # Compute the FFT of the stress-volume fields along the last two axes (spatial dimensions).
+    stress_fft = rfftn(
+        stress_volume,
+        s=fft_shape,
+        axes=(-2, -1),
+    )
+
+    results: list[MetricResult] = []
+    for metric, operator in zip(metrics, operators, strict=True):
+        kernel_fft = metric._kernel_fft_cache.get(fft_shape)
+        if kernel_fft is None:
+            flipped_kernels = np.flip(
+                operator.virtual_strain_fields,
+                axis=(-2, -1),
+            )
+            kernel_fft = rfftn(
+                flipped_kernels,
+                s=fft_shape,
+                axes=(-2, -1),
+            )
+            metric._kernel_fft_cache[fft_shape] = kernel_fft
+
+        gaps: list[npt.NDArray[np.float64]] = []
+        window_rows = int(metric.window_size[0])
+        window_cols = int(metric.window_size[1])
+        row_start = (window_rows - 1) // 2
+        col_start = (window_cols - 1) // 2
+        for field_fft in kernel_fft:
+            gap_fft = np.sum(
+                stress_fft * field_fft[np.newaxis],
+                axis=1,
+            )
+            padded_gap = irfftn(
+                gap_fft,
+                s=fft_shape,
+                axes=(-2, -1),
+            )
+            gaps.append(
+                padded_gap[
+                    :,
+                    row_start:row_start + stress.shape[2],
+                    col_start:col_start + stress.shape[3],
+                ]
+            )
+
+        raw_gap = gaps[0] if len(gaps) == 1 else 0.5 * (
+            np.abs(gaps[0]) + np.abs(gaps[1])
+        )
+        results.append(
+            metric._result_from_raw_gap(
+                raw_gap,
+                include_diagnostics=include_diagnostics,
+            ).metric_result
+        )
+    return results
 
 
 def _validate_window_definition(

--- a/src/pyvale/vfm/optimiser.py
+++ b/src/pyvale/vfm/optimiser.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import cast
 
 import numpy as np
 import numpy.typing as npt
@@ -7,6 +8,10 @@ from pyvale.vfm.constlaw import IConstitutiveLaw
 from pyvale.vfm.experimentdata import ExperimentData
 from pyvale.vfm.identificationresult import OptimisationOutcome
 from pyvale.vfm.metric import IMetric, MetricResult
+from pyvale.vfm.metricequilibriumgap import (
+    EquilibriumGapMetric,
+    evaluate_equilibrium_gap_batch,
+)
 from pyvale.vfm.objectivefunc import IObjectiveFunction
 from pyvale.vfm.spatialparam import (
     ISpatialParameterisation,
@@ -129,16 +134,96 @@ def evaluate_candidate(
         experiment_data.strain, updated_constitutive_parameter_maps,
     )
 
-    metric_results: list[MetricResult] = []
-    for metric in metrics:
-        metric_results.append(
-            metric.evaluate(
+    metric_results: list[MetricResult | None] = [None] * len(metrics)
+
+    # Evaluate compatible EquilibriumGapMetrics in batches to improve performance
+    batched_results = _evaluate_batched_equilibrium_gap_metrics(
+        updated_stress,
+        metrics,
+    )
+
+    # Evaluate remaining metrics individually
+    for index, metric in enumerate(metrics):
+        if index in batched_results:
+            metric_results[index] = batched_results[index]
+            continue
+        if isinstance(metric, EquilibriumGapMetric):
+            metric_results[index] = metric.evaluate_equilibrium_gap(
+                updated_stress,
+                include_diagnostics=metric.include_optimisation_diagnostics,
+            ).metric_result
+            continue
+        metric_results[index] = metric.evaluate(
                 updated_stress,
                 constitutive_law,
                 parameter_map_size,
                 updated_spatial_parameterisations,
                 experiment_data,
-            ),
-        )
+            )
 
-    return objective_function.evaluate(metric_results)
+    if any(result is None for result in metric_results):
+        raise RuntimeError("A candidate metric evaluation did not produce a result.")
+    return objective_function.evaluate(
+        [result for result in metric_results if result is not None]
+    )
+
+
+def _evaluate_batched_equilibrium_gap_metrics(
+    stress: npt.NDArray[np.float64],
+    metrics: list[IMetric],
+) -> dict[int, MetricResult]:
+    """Evaluate compatible equilibrium-gap metrics in shared FFT batches.
+
+    Metrics are compatible when they use the same integration volume and
+    optimisation diagnostic setting. Results are keyed by the metrics'
+    original positions; unbatched metrics are omitted for the caller to
+    evaluate individually.
+    """
+    results: dict[int, MetricResult] = {}
+    remaining_egi_indices = [
+        index
+        for index, metric in enumerate(metrics)
+        if isinstance(metric, EquilibriumGapMetric)
+    ]
+    while remaining_egi_indices:
+        first_index = remaining_egi_indices.pop(0)
+        first_metric = metrics[first_index]
+        if not isinstance(first_metric, EquilibriumGapMetric):
+            raise RuntimeError("Expected an equilibrium-gap metric.")
+        first_operator = first_metric._operator
+        compatible_indices = [first_index]
+        incompatible_indices = []
+        for index in remaining_egi_indices:
+            metric = metrics[index]
+            if not isinstance(metric, EquilibriumGapMetric):
+                raise RuntimeError("Expected an equilibrium-gap metric.")
+            operator = metric._operator
+            if (
+                first_operator is not None
+                and operator is not None
+                and np.array_equal(first_operator.volume, operator.volume)
+                and metric.include_optimisation_diagnostics
+                == first_metric.include_optimisation_diagnostics
+            ):
+                compatible_indices.append(index)
+            else:
+                incompatible_indices.append(index)
+        remaining_egi_indices = incompatible_indices
+        if len(compatible_indices) < 2:
+            continue
+        egi_metrics = [
+            cast(EquilibriumGapMetric, metrics[index])
+            for index in compatible_indices
+        ]
+        batched_results = evaluate_equilibrium_gap_batch(
+            stress,
+            egi_metrics,
+            include_diagnostics=first_metric.include_optimisation_diagnostics,
+        )
+        for index, result in zip(
+            compatible_indices,
+            batched_results,
+            strict=True,
+        ):
+            results[index] = result
+    return results

--- a/src/pyvale/vfm/optimiserslicewiseindependent.py
+++ b/src/pyvale/vfm/optimiserslicewiseindependent.py
@@ -121,6 +121,11 @@ class SliceWiseIndependentLeastSquares(IOptimiser):
                 local_slice_data.unknown_parameter_names,
             )
 
+            slice_constitutive_law = _prepare_slice_constitutive_law(
+                constitutive_law,
+                local_slice_data,
+            )
+
             _emit_slice_progress(
                 progress_callback,
                 kind="slice_started",
@@ -134,7 +139,7 @@ class SliceWiseIndependentLeastSquares(IOptimiser):
                 bounds=(np.zeros_like(initial_guess), np.ones_like(initial_guess)),
                 method=self.method,
                 args=(
-                    constitutive_law,
+                    slice_constitutive_law,
                     objective_function,
                     slice_metric,
                     experiment_data,
@@ -489,6 +494,41 @@ def _build_initial_guess(
         slice_degrees_of_freedom.append(copy.copy(slice_value))
 
     return normalise_degrees_of_freedom(slice_degrees_of_freedom)
+
+
+def _prepare_slice_constitutive_law(
+    constitutive_law: IConstitutiveLaw,
+    local_slice_data: LocalSliceData,
+) -> IConstitutiveLaw:
+    """Prepare invariant constitutive inputs once for one slice solve.
+
+    The phase law may already be prepared for the complete strain field. Its
+    preparation hook returns a shallow copy and replaces that full-field cache
+    with inputs matching this slice's filtered local points. The resulting law
+    is then reused by every candidate evaluation for this slice.
+    """
+    prepare = getattr(constitutive_law, "prepare_for_optimisation", None)
+    if prepare is None or not getattr(constitutive_law, "cache_radial_return", True):
+        return constitutive_law
+
+    elastic_labels = (
+        getattr(constitutive_law, "elastic_modulus_label", None),
+        getattr(constitutive_law, "poissons_ratio_label", None),
+    )
+    fixed_elastic_maps = None
+    if all(isinstance(label, str) for label in elastic_labels) and all(
+        label in local_slice_data.fixed_parameter_maps for label in elastic_labels
+    ):
+        fixed_elastic_maps = {
+            label: local_slice_data.fixed_parameter_maps[label]
+            for label in elastic_labels
+        }
+
+    return prepare(
+        local_slice_data.local_strain,
+        error_tolerance=getattr(constitutive_law, "error_tolerance", 1.0e-8),
+        fixed_elastic_parameter_maps=fixed_elastic_maps,
+    )
 
 
 def _extract_local_strain(

--- a/src/pyvale/vfm/radialreturn.py
+++ b/src/pyvale/vfm/radialreturn.py
@@ -1,9 +1,104 @@
 import enum
+from dataclasses import dataclass
 
 import numpy as np
 import numpy.typing as npt
 
 from pyvale.vfm.hardening import IHardeningFunction
+
+
+@dataclass(slots=True, frozen=True)
+class RadialReturnPreparedInputs:
+    """Immutable inputs that may be reused across stress reconstructions.
+
+    ``incremental_strain`` is valid whenever the measured strain history is
+    unchanged. ``elastic_stress_increment`` is populated only when both
+    elastic parameter maps are fixed for the lifetime of the prepared data.
+    """
+
+    strain_shape: tuple[int, int, int, int]
+    incremental_strain: npt.NDArray[np.float64]
+    elastic_stress_increment: npt.NDArray[np.float64] | None = None
+    elastic_modulus_flat: npt.NDArray[np.float64] | None = None
+    poissons_ratio_flat: npt.NDArray[np.float64] | None = None
+    shear_modulus_flat: npt.NDArray[np.float64] | None = None
+
+
+def prepare_radial_return_inputs(
+    strain: npt.NDArray[np.float64],
+    *,
+    elastic_modulus: npt.NDArray[np.float64] | None = None,
+    poissons_ratio: npt.NDArray[np.float64] | None = None,
+) -> RadialReturnPreparedInputs:
+    """Prepare strain and, optionally, fixed-elasticity radial-return data.
+
+    Supplying neither elastic map caches only strain increments. Supplying
+    both additionally caches the plane-stress elastic stress increment. The
+    latter is appropriate only when ``elastic_modulus`` and ``poissons_ratio``
+    are known and fixed throughout the optimisation phase.
+    """
+
+    if strain.ndim != 4 or strain.shape[1] != 3:
+        raise ValueError("strain must have shape (timesteps, 3, y, x)")
+    if (elastic_modulus is None) != (poissons_ratio is None):
+        raise ValueError(
+            "elastic_modulus and poissons_ratio must either both be supplied "
+            "or both be omitted."
+        )
+
+    # Compute incremental strain from the full strain history. The first
+    # timestep is treated as an increment from zero strain.
+    incremental_strain = np.empty_like(strain)
+    incremental_strain[0] = strain[0]
+    incremental_strain[1:] = np.diff(strain, axis=0)
+    # Convert tensorial shear strain to engineering shear strain
+    incremental_strain[:, 2] *= 2.0
+    # Set the write flag to False to prevent accidental modification of
+    # the incremental strain array.
+    incremental_strain.setflags(write=False)
+
+    elastic_stress_increment = None
+    elastic_modulus_flat = None
+    poissons_ratio_flat = None
+    shear_modulus_flat = None
+    if elastic_modulus is not None and poissons_ratio is not None:
+        expected_shape = strain.shape[2:]
+        if elastic_modulus.shape != expected_shape or poissons_ratio.shape != expected_shape:
+            raise ValueError(
+                "elastic parameter maps must match the strain spatial shape "
+                f"{expected_shape}."
+            )
+        plane_stress_factor = elastic_modulus / (1.0 - poissons_ratio**2)
+        shear_modulus = elastic_modulus / (2.0 * (1.0 + poissons_ratio))
+        elastic_stress_increment = np.empty_like(strain)
+        elastic_stress_increment[:, 0] = plane_stress_factor * (
+            incremental_strain[:, 0]
+            + poissons_ratio[np.newaxis] * incremental_strain[:, 1]
+        )
+        elastic_stress_increment[:, 1] = plane_stress_factor * (
+            poissons_ratio[np.newaxis] * incremental_strain[:, 0]
+            + incremental_strain[:, 1]
+        )
+        elastic_stress_increment[:, 2] = (
+            shear_modulus[np.newaxis] * incremental_strain[:, 2]
+        )
+        # Set the write flag to False to prevent accidental modification
+        elastic_stress_increment.setflags(write=False)
+        elastic_modulus_flat = np.array(elastic_modulus, copy=True).ravel()
+        poissons_ratio_flat = np.array(poissons_ratio, copy=True).ravel()
+        shear_modulus_flat = np.array(shear_modulus, copy=True).ravel()
+        elastic_modulus_flat.setflags(write=False)
+        poissons_ratio_flat.setflags(write=False)
+        shear_modulus_flat.setflags(write=False)
+
+    return RadialReturnPreparedInputs(
+        strain_shape=tuple(strain.shape),
+        incremental_strain=incremental_strain,
+        elastic_stress_increment=elastic_stress_increment,
+        elastic_modulus_flat=elastic_modulus_flat,
+        poissons_ratio_flat=poissons_ratio_flat,
+        shear_modulus_flat=shear_modulus_flat,
+    )
 
 
 class EUnloading(enum.Enum):
@@ -33,6 +128,7 @@ def radial_return(
     error_tolerance: float = 1e-8,
     iteration_limit: int = 100,
     unloading: EUnloading = EUnloading.ConstantStrain,
+    prepared_inputs: RadialReturnPreparedInputs | None = None,
 ) -> tuple[
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],
@@ -58,6 +154,11 @@ def radial_return(
         - NoCompensation: no output correction on unloading
         - ConstantStrain: hold previous output stress (default)
         - LinearExtrapolation: extrapolate from two previous outputs
+    prepared_inputs : RadialReturnPreparedInputs, optional
+        Reusable strain increments and, for a phase with fixed elastic
+        properties, elastic stress increments. Create with
+        :func:`prepare_radial_return_inputs` and do not reuse after changing
+        the strain history or fixed elastic maps.
 
     Returns
     -------
@@ -138,21 +239,37 @@ def radial_return(
     size_x = strain.shape[3]
     num_datapoints = size_y * size_x
 
-    # Elastic modulus and poissons ratio are always required to compute trial elastic stress
-    elastic_modulus = constitutive_parameter_maps["elastic_modulus"]
-    poissons_ratio = constitutive_parameter_maps["poissons_ratio"]
+    if elastic_modulus.shape != (size_y, size_x):
+        raise ValueError("elastic_modulus must match the strain spatial shape")
+    if poissons_ratio.shape != (size_y, size_x):
+        raise ValueError("poissons_ratio must match the strain spatial shape")
+    if prepared_inputs is not None and prepared_inputs.strain_shape != tuple(strain.shape):
+        raise ValueError("prepared radial-return inputs do not match strain shape")
 
-    # == COMPUTE PLANE STRESS FACTOR (AND / OR ELASTIC STIFFNESS MATRIX) ==
-    shear_modulus = elastic_modulus / (2 * (1 + poissons_ratio))     
-
-    # Plane stress factor used rather than elastic stiffness matrix to more easily
-    # support spatially varying material properties without needing to construct
-    # a full elastic stiffness matrix for each point.
-    plane_stress_factor = elastic_modulus / (1 - poissons_ratio ** 2)
-
-    elastic_modulus_flat = elastic_modulus.ravel()
-    poissons_ratio_flat = poissons_ratio.ravel()
-    shear_modulus_flat = shear_modulus.ravel()
+    fixed_elastic_cache = (
+        prepared_inputs is not None
+        and prepared_inputs.elastic_stress_increment is not None
+    )
+    if fixed_elastic_cache:
+        elastic_modulus_flat = prepared_inputs.elastic_modulus_flat
+        poissons_ratio_flat = prepared_inputs.poissons_ratio_flat
+        shear_modulus_flat = prepared_inputs.shear_modulus_flat
+        if (
+            elastic_modulus_flat is None
+            or poissons_ratio_flat is None
+            or shear_modulus_flat is None
+        ):
+            raise ValueError("fixed-elasticity prepared inputs are incomplete")
+        shear_modulus = None
+        plane_stress_factor = None
+    else:
+        shear_modulus = elastic_modulus / (2 * (1 + poissons_ratio))
+        # Plane stress factor supports spatially varying elastic properties
+        # without constructing a stiffness matrix at every point.
+        plane_stress_factor = elastic_modulus / (1 - poissons_ratio ** 2)
+        elastic_modulus_flat = elastic_modulus.ravel()
+        poissons_ratio_flat = poissons_ratio.ravel()
+        shear_modulus_flat = shear_modulus.ravel()
  
     # Old: explicit elastic stiffness matrix for plane stress with engineering shear strain (only required if 
     #       we want to do the elastic predictor with a single matrix multiply or output the stiffness matrix for some reason)
@@ -167,15 +284,12 @@ def radial_return(
 
     # == COMPUTE INCREMENTAL STRAINS ==
     # The return-mapping algorithm works with strain increments. 
-    incremental_strain = np.zeros_like(strain) 
-    incremental_strain[0, :, :, :] = strain[0, :, :, :] # First timestep uses the total strain as the first increment
-    incremental_strain[1:, :, :, :] = np.diff(strain, axis=0)
-
-    # Convert tensorial shear strain component to engineering shear strain
-    # The constitutive matrix D is written using engineering shear strain gamma_xy,
-    # while the incoming field is assumed to contain tensorial shear epsilon_xy. 
-    # Need to confirm that the Python strain input is provided as tensorial strain.
-    incremental_strain[:, 2, :, :] *= 2    
+    if prepared_inputs is None:
+        incremental_strain = prepare_radial_return_inputs(strain).incremental_strain
+        elastic_stress_increment = None
+    else:
+        incremental_strain = prepared_inputs.incremental_strain
+        elastic_stress_increment = prepared_inputs.elastic_stress_increment
 
 
     # == INITIALISE VARIABLES FOR RADIAL RETURN ==
@@ -214,19 +328,34 @@ def radial_return(
 
         # xx component of trial stress at each point (shape: y, x)
         # sig_xx = sig_xx_prev + plane_stress_factor * (delta_eps_xx + nu * delta_eps_yy)
-        trial_stress_xx = stress_state[t_prev, 0, :, :] + plane_stress_factor * (
-            incremental_strain[t, 0, :, :] + poissons_ratio * incremental_strain[t, 1, :, :]
-        )
+        if elastic_stress_increment is None:
+            trial_stress_xx = stress_state[t_prev, 0, :, :] + plane_stress_factor * (
+                incremental_strain[t, 0, :, :] + poissons_ratio * incremental_strain[t, 1, :, :]
+            )
+        else:
+            trial_stress_xx = (
+                stress_state[t_prev, 0, :, :] + elastic_stress_increment[t, 0]
+            )
 
         # yy component of trial stress at each point (shape: y, x)
         # sig_yy = sig_yy_prev + plane_stress_factor * (delta_eps_yy + nu * delta_eps_xx)
-        trial_stress_yy = stress_state[t_prev, 1, :, :] + plane_stress_factor * (
-            poissons_ratio * incremental_strain[t, 0, :, :] + incremental_strain[t, 1, :, :]
-        )
+        if elastic_stress_increment is None:
+            trial_stress_yy = stress_state[t_prev, 1, :, :] + plane_stress_factor * (
+                poissons_ratio * incremental_strain[t, 0, :, :] + incremental_strain[t, 1, :, :]
+            )
+        else:
+            trial_stress_yy = (
+                stress_state[t_prev, 1, :, :] + elastic_stress_increment[t, 1]
+            )
 
         # xy component of trial stress at each point (shape: y, x)
         # sig_xy = sig_xy_prev + G * delta_gamma_xy  (note: shear strain is engineering shear strain, so no factor of 2 needed here)
-        trial_stress_xy = stress_state[t_prev, 2, :, :] + shear_modulus * incremental_strain[t, 2, :, :]
+        if elastic_stress_increment is None:
+            trial_stress_xy = stress_state[t_prev, 2, :, :] + shear_modulus * incremental_strain[t, 2, :, :]
+        else:
+            trial_stress_xy = (
+                stress_state[t_prev, 2, :, :] + elastic_stress_increment[t, 2]
+            )
        
         # Keep the component fields flattened through the return mapping. This
         # avoids stacking and transposing the full stress field each timestep.
@@ -330,7 +459,7 @@ def radial_return(
                 / (1 + 2 * shear_modulus_flat * plastic_multiplier) ** 3
             )
 
-            # Only update plastic points as elastic points have plastic_multiplier = 0 and 
+            # Only update plastic points as elastic points have plastic_multiplier = 0 and
             # do not need to be updated in the iteration
             delta_ksi_plastic_multiplier[plasticity_mask] = (
                 delta_ksi_plastic_multiplier_all[plasticity_mask]

--- a/src/pyvale/vfm/validation.py
+++ b/src/pyvale/vfm/validation.py
@@ -251,6 +251,16 @@ def _collect_identification_config_errors(
                 f"phase {i} must have at least one metric"
             )
 
+        # Check that the radial return Newton-Raphson tolerance is finite and positive.
+        if (
+            not np.isfinite(phase.optimisation_newton_tolerance)
+            or phase.optimisation_newton_tolerance <= 0.0
+        ):
+            errors.append(
+                f"phase {i}: optimisation_newton_tolerance must be finite "
+                "and greater than zero"
+            )
+
         errors.extend(
             _collect_slicewise_independent_phase_errors(
                 phase,

--- a/tests/vfm/test_constlaws.py
+++ b/tests/vfm/test_constlaws.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from pyvale.vfm.constlaws import IsotropicVonMisesElastoplasticity
+from pyvale.vfm.hardening import HardeningLinear
+from pyvale.vfm.optimiserslicewiseindependent import (
+    _prepare_slice_constitutive_law,
+)
+
+
+def test_phase_prepared_constitutive_law_keeps_final_tolerance_independent() -> None:
+    strain = np.zeros((8, 3, 2, 3), dtype=np.float64)
+    strain[:, 0] = np.linspace(0.0, 0.006, strain.shape[0])[:, None, None]
+    maps = {
+        "elastic_modulus": np.full((2, 3), 190_000.0),
+        "poissons_ratio": np.full((2, 3), 0.28),
+        "yield_strength": np.full((2, 3), 320.0),
+        "hardening_modulus": np.full((2, 3), 3_000.0),
+    }
+    law = IsotropicVonMisesElastoplasticity(HardeningLinear())
+
+    prepared = law.prepare_for_optimisation(
+        strain,
+        error_tolerance=1.0e-6,
+        fixed_elastic_parameter_maps=maps,
+    )
+
+    assert law.error_tolerance == 1.0e-8
+    assert law._prepared_inputs is None
+    assert prepared.error_tolerance == 1.0e-6
+    assert prepared._prepared_inputs is not None
+    assert prepared._prepared_inputs.elastic_stress_increment is not None
+    reference = law.calculate_stress(strain, maps)
+    relaxed = prepared.calculate_stress(strain, maps)
+    np.testing.assert_allclose(relaxed, reference, rtol=1.0e-5, atol=1.0e-3)
+
+
+def test_custom_elastic_parameter_labels_are_used_by_radial_return() -> None:
+    strain = np.zeros((3, 3, 1, 1), dtype=np.float64)
+    strain[:, 0, 0, 0] = [0.0, 1.0e-4, 2.0e-4]
+    maps = {
+        "youngs": np.full((1, 1), 200_000.0),
+        "nu": np.full((1, 1), 0.3),
+        "yield_strength": np.full((1, 1), 1.0e9),
+        "hardening_modulus": np.zeros((1, 1)),
+    }
+    law = IsotropicVonMisesElastoplasticity(
+        HardeningLinear(),
+        elastic_modulus_label="youngs",
+        poissons_ratio_label="nu",
+    )
+
+    stress = law.calculate_stress(strain, maps)
+    expected_xx = 200_000.0 / (1.0 - 0.3**2) * strain[:, 0, 0, 0]
+    np.testing.assert_allclose(stress[:, 0, 0, 0], expected_xx)
+
+
+def test_slice_law_prepares_local_strain_and_fixed_elastic_maps() -> None:
+    strain = np.zeros((4, 3, 1, 2), dtype=np.float64)
+    fixed_maps = {
+        "elastic_modulus": np.full((1, 2), 190_000.0),
+        "poissons_ratio": np.full((1, 2), 0.28),
+    }
+    law = IsotropicVonMisesElastoplasticity(HardeningLinear())
+    full_strain = np.zeros((4, 3, 2, 3), dtype=np.float64)
+    full_maps = {
+        "elastic_modulus": np.full((2, 3), 190_000.0),
+        "poissons_ratio": np.full((2, 3), 0.28),
+    }
+    phase_law = law.prepare_for_optimisation(
+        full_strain,
+        error_tolerance=1.0e-6,
+        fixed_elastic_parameter_maps=full_maps,
+    )
+
+    slice_law = _prepare_slice_constitutive_law(
+        phase_law,
+        SimpleNamespace(local_strain=strain, fixed_parameter_maps=fixed_maps),
+    )
+
+    assert slice_law is not phase_law
+    assert slice_law.hardening_function is phase_law.hardening_function
+    assert slice_law.error_tolerance == 1.0e-6
+    assert slice_law._prepared_inputs is not None
+    assert slice_law._prepared_inputs.strain_shape == strain.shape
+    assert slice_law._prepared_inputs.elastic_stress_increment is not None
+    assert phase_law._prepared_inputs is not None
+    assert phase_law._prepared_inputs.strain_shape == full_strain.shape
+
+
+def test_prepared_law_can_disable_radial_return_caching() -> None:
+    strain = np.zeros((3, 3, 1, 1), dtype=np.float64)
+    maps = {
+        "elastic_modulus": np.full((1, 1), 190_000.0),
+        "poissons_ratio": np.full((1, 1), 0.28),
+        "yield_strength": np.full((1, 1), 320.0),
+        "hardening_modulus": np.full((1, 1), 3_000.0),
+    }
+    law = IsotropicVonMisesElastoplasticity(HardeningLinear())
+
+    uncached = law.prepare_for_optimisation(
+        strain,
+        error_tolerance=1.0e-6,
+        fixed_elastic_parameter_maps=maps,
+        cache_radial_return=False,
+    )
+
+    assert not uncached.cache_radial_return
+    assert uncached._prepared_inputs is None
+    np.testing.assert_allclose(
+        uncached.calculate_stress(strain, maps),
+        law.calculate_stress(strain, maps),
+    )

--- a/tests/vfm/test_metricequilibriumgap.py
+++ b/tests/vfm/test_metricequilibriumgap.py
@@ -16,7 +16,9 @@ from pyvale.vfm.experimentdata import (
 from pyvale.vfm.metricequilibriumgap import (
     EquilibriumGapMetric,
     EquilibriumGapVirtualFieldType,
+    evaluate_equilibrium_gap_batch,
 )
+from pyvale.vfm.optimiser import _evaluate_batched_equilibrium_gap_metrics
 from pyvale.vfm.roi import RoiDefinition, RoiShape, VfmRegionOfInterest
 
 
@@ -224,6 +226,76 @@ def test_common_stress_and_force_scaling_leaves_normalised_gap_unchanged() -> No
         rtol=1.0e-12,
         atol=1.0e-12,
     )
+
+
+def test_batched_windows_match_independent_fft_correlations() -> None:
+    experiment_data = _rectangle_experiment_data(rows=23, cols=27)
+    stress = _stress_with_central_inclusion(experiment_data)
+    metrics = [
+        EquilibriumGapMetric(window_size=(5, 5)),
+        EquilibriumGapMetric(window_size=(9, 9)),
+    ]
+    for metric in metrics:
+        metric.initialise(experiment_data)
+
+    independent = [metric.evaluate_equilibrium_gap(stress) for metric in metrics]
+    batched = evaluate_equilibrium_gap_batch(
+        stress,
+        metrics,
+        include_diagnostics=True,
+    )
+
+    for expected, actual in zip(independent, batched, strict=True):
+        np.testing.assert_allclose(
+            actual.residual,
+            expected.normalised_gap,
+            rtol=2.0e-12,
+            atol=2.0e-12,
+            equal_nan=True,
+        )
+        assert actual.additional_fields is not None
+        assert actual.additional_fields["weighted_spatiotemporal_rms"] == pytest.approx(
+            expected.weighted_spatiotemporal_rms,
+            rel=2.0e-12,
+            abs=2.0e-12,
+        )
+
+
+def test_optimiser_batch_helper_returns_results_by_metric_index() -> None:
+    experiment_data = _rectangle_experiment_data(rows=23, cols=27)
+    stress = _stress_with_central_inclusion(experiment_data)
+    metrics = [
+        EquilibriumGapMetric(window_size=(5, 5)),
+        EquilibriumGapMetric(window_size=(9, 9)),
+    ]
+    for metric in metrics:
+        metric.initialise(experiment_data)
+
+    results = _evaluate_batched_equilibrium_gap_metrics(stress, metrics)
+
+    assert set(results) == {0, 1}
+    assert all(result.additional_fields is not None for result in results.values())
+
+
+def test_objective_only_egi_result_omits_diagnostic_fields() -> None:
+    experiment_data = _rectangle_experiment_data()
+    assert EquilibriumGapMetric().include_optimisation_diagnostics
+    metric = EquilibriumGapMetric(
+        window_size=(5, 5),
+        include_optimisation_diagnostics=False,
+    )
+    metric.initialise(experiment_data)
+
+    result = metric.evaluate_equilibrium_gap(
+        _stress_with_central_inclusion(experiment_data),
+        include_diagnostics=metric.include_optimisation_diagnostics,
+    ).metric_result
+
+    assert result.residual is None
+    assert set(result.additional_fields) == {
+        "weighted_spatiotemporal_rms",
+        "window_size",
+    }
 
 
 def test_windows_can_cross_free_edges_but_not_non_free_edges() -> None:

--- a/tests/vfm/test_objectivefunccombinedfreegi.py
+++ b/tests/vfm/test_objectivefunccombinedfreegi.py
@@ -129,3 +129,34 @@ def test_scalar_egi_aggregation_is_not_rms_of_a_combined_map() -> None:
     assert scalar_cost == scalar_egi
     assert combined_map_rms == 1.0
     assert scalar_cost != combined_map_rms
+
+
+def test_combined_objective_accepts_compact_metric_results() -> None:
+    objective = CombinedForceAndEquilibriumGapObjective(
+        force_weight=0.25,
+        egi_baseline_values=(2.0, 4.0),
+        force_baseline_value=5.0,
+        egi_window_weights=(1.0, 3.0),
+    )
+    compact_results = [
+        MetricResult(
+            additional_fields={
+                "reconstructed_force": np.zeros(1),
+                "normalised_residual": np.asarray([15.0]),
+            }
+        ),
+        MetricResult(
+            additional_fields={
+                "weighted_spatiotemporal_rms": 4.0,
+                "window_size": np.asarray([5, 5]),
+            }
+        ),
+        MetricResult(
+            additional_fields={
+                "weighted_spatiotemporal_rms": 8.0,
+                "window_size": np.asarray([9, 9]),
+            }
+        ),
+    ]
+
+    assert objective.evaluate(compact_results) == 2.25

--- a/tests/vfm/test_radial_return.py
+++ b/tests/vfm/test_radial_return.py
@@ -1,9 +1,18 @@
 """Regression tests for the vectorised plane-stress radial-return mapping."""
 
+from pathlib import Path
+
 import numpy as np
 
 from pyvale.vfm.hardening import HardeningLinear
-from pyvale.vfm.radialreturn import EUnloading, radial_return
+from pyvale.vfm.radialreturn import (
+    EUnloading,
+    prepare_radial_return_inputs,
+    radial_return,
+)
+
+
+FIXTURE_PATH = Path(__file__).parent / "gold" / "radial_return_downsampled_case.npz"
 
 
 def _maps(
@@ -136,6 +145,76 @@ def test_radial_return_handles_mixed_elastic_and_plastic_heterogeneous_points() 
     assert not yield_map[-1, 1, 1]
     assert peeq[-1, 0, 0] > 0.0
     assert peeq[-1, 1, 1] == 0.0
+
+
+def test_prepared_radial_return_inputs_match_uncached_path() -> None:
+    maps = _maps((2, 3))
+    maps["yield_strength"][0, 0] = 150.0
+    strain = np.zeros((14, 3, 2, 3), dtype=np.float64)
+    strain[:, 0] = np.linspace(0.0, 0.006, strain.shape[0])[:, None, None]
+    strain[:, 1] = 0.2 * strain[:, 0]
+    strain[:, 2] = -0.1 * strain[:, 0]
+
+    reference = _radial_return(strain, maps)
+    prepared = prepare_radial_return_inputs(
+        strain,
+        elastic_modulus=maps["elastic_modulus"],
+        poissons_ratio=maps["poissons_ratio"],
+    )
+    cached = radial_return(
+        strain,
+        maps,
+        maps["elastic_modulus"],
+        maps["poissons_ratio"],
+        HardeningLinear(),
+        unloading=EUnloading.NoCompensation,
+        prepared_inputs=prepared,
+    )
+
+    for actual, expected in zip(cached, reference, strict=True):
+        np.testing.assert_allclose(actual, expected, rtol=1.0e-13, atol=1.0e-13)
+
+
+def test_radial_return_real_data_regression_fixture() -> None:
+    with np.load(FIXTURE_PATH, allow_pickle=False) as fixture:
+        strain = fixture["strain"]
+        shape = strain.shape[2:]
+        maps = _maps(
+            shape,
+            elastic_modulus=float(fixture["elastic_modulus"]),
+            poissons_ratio=float(fixture["poissons_ratio"]),
+            yield_strength=float(fixture["yield_strength"]),
+            hardening_modulus=float(fixture["hardening_modulus"]),
+        )
+        unloading = {
+            "constant_strain": EUnloading.ConstantStrain,
+            "no_compensation": EUnloading.NoCompensation,
+            "linear_extrapolation": EUnloading.LinearExtrapolation,
+        }[str(fixture["unloading_mode"])]
+        actual = radial_return(
+            strain,
+            maps,
+            maps["elastic_modulus"],
+            maps["poissons_ratio"],
+            HardeningLinear(),
+            error_tolerance=float(fixture["error_tolerance"]),
+            iteration_limit=int(fixture["iteration_limit"]),
+            unloading=unloading,
+        )
+        expected = (
+            fixture["stress_expected"],
+            fixture["equivalent_stress_expected"],
+            fixture["yield_map_expected"],
+            fixture["peeq_expected"],
+        )
+
+    for actual_value, expected_value in zip(actual, expected, strict=True):
+        np.testing.assert_allclose(
+            actual_value,
+            expected_value,
+            rtol=1.0e-12,
+            atol=1.0e-12,
+        )
 
 # ---------------------------------------------------------------------------
 # Legacy commented tests retained for future reference.


### PR DESCRIPTION
Added optional caching of invariant quantities to speed up radial return repeated evaluations.
Implemented batch evaluation of egi metrics to improve performance. also changed some egi outputs to optional